### PR TITLE
[codex] Simplify public documentation wording

### DIFF
--- a/DATA_POLICY.md
+++ b/DATA_POLICY.md
@@ -1,26 +1,28 @@
-# Data and Artifact Policy
+# Data and Artifact Scope
 
-This repository is intended to contain source code, documentation, configuration examples, and a few small illustrative images only.
+This repository contains source code, documentation, configuration examples, and a compact illustrative visualization.
 
-Do not commit:
+## External Artifacts
 
-- raw KMA HSR archives or extracted `.bin.gz` files
-- generated datasets, checkpoints, Excel reports, or bulk visualizations
-- local absolute paths, API keys, W&B credentials, access tokens, or private experiment metadata
-- notebooks with executed outputs that reveal local paths, logs, machine names, or private file names
+The following artifacts are distributed or generated outside the repository:
+
+- raw KMA HSR archives and extracted `.bin.gz` files
+- generated datasets and train/validation/test splits
+- trained checkpoints and model weight files
+- Excel reports, bulk predictions, and visualization batches
+- private run metadata such as local paths, W&B credentials, and access tokens
+- executed notebook outputs that expose local logs, machine names, or private file names
 
 Recommended local layout:
 
 ```text
 data/
-  archives/        # original .tar.gz files, ignored by git
-  raw/             # extracted .bin.gz files, ignored by git
-  dBZ_png/         # converted PNG files, ignored by git
-  dataset_.../     # train/valid/test split, ignored by git
-checkpoints/       # model weights, ignored by git
-outputs/           # evaluation reports and generated visualizations, ignored by git
+  archives/
+  raw/
+  dBZ_png/
+  dataset_.../
+checkpoints/
+outputs/
 ```
 
-The README links to the public data source. Keep large data and trained weights in an external data/model registry such as Zenodo, Hugging Face, institutional storage, or a GitHub Release when licensing allows it.
-
-If a credential was ever committed, revoke and rotate it at the provider first. Git history cleanup reduces exposure in the repository, but it does not guarantee that external caches, forks, clones, or provider-side logs have forgotten the value.
+The README links to the public Zenodo record for the dataset and pretrained models. Additional releases can use an external data/model registry such as Zenodo, Hugging Face, institutional storage, or GitHub Releases when licensing allows it.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The work is associated with the paper **"Improving Deep Learning-Based Precipita
 - CLI single-model and weighted-ensemble evaluation scripts
 - A small sample visualization image under `examples/visualizations/`
 
-Large raw data, generated datasets, trained checkpoints, Excel reports, and bulk visualizations are intentionally not stored in git. See [DATA_POLICY.md](DATA_POLICY.md).
+The large dataset and trained checkpoints are distributed separately through Zenodo. This repository focuses on source code, configuration examples, documentation, and a compact visualization sample.
 
 ## Example Results
 
@@ -38,7 +38,7 @@ The dataset and pretrained models used in the paper are available from Zenodo:
 
 [https://doi.org/10.5281/zenodo.14608083](https://doi.org/10.5281/zenodo.14608083)
 
-Recommended local directory layout:
+Recommended local directory layout for reproduction:
 
 ```text
 data/
@@ -49,8 +49,6 @@ data/
 checkpoints/
 outputs/
 ```
-
-These paths are ignored by git.
 
 ## Preprocessing
 
@@ -103,14 +101,11 @@ python Code/main.py \
 
 Available model names are `unet`, `seunet`, `attunet`, `dualattunet`, and `sarunet`.
 
-Weights & Biases logging is disabled by default. To enable it, set your key in the environment and pass `--wandb`:
+Weights & Biases logging is disabled by default. To enable it, set `WANDB_API_KEY` in your environment and pass `--wandb`:
 
 ```bash
-export WANDB_API_KEY="your-key"
 python Code/main.py ... --wandb --wandb_project precipitation-nowcasting
 ```
-
-Do not commit W&B keys or generated `wandb/` directories.
 
 ## Evaluation
 
@@ -127,6 +122,8 @@ python Code/evaluate_models.py \
 For older full-model `.pth` files created with `torch.save(model, path)`, add `--allow-full-model` only when the checkpoint is trusted.
 
 ## Ensemble Evaluation
+
+The included `configs/model_weights.example.json` describes a four-model ensemble example. If you change the model list, update the ensemble weights so the number of weights matches the number of configured models.
 
 Evaluate one weighted ensemble:
 
@@ -149,7 +146,7 @@ python Code/evaluate_ensemble.py \
   --output outputs/ensemble_grid_search_results.xlsx
 ```
 
-Generated predictions and visualizations should stay under `outputs/`, not in git.
+Evaluation reports and generated visualizations are written under `outputs/` by default.
 
 ## Citation
 


### PR DESCRIPTION
## Summary

This PR trims internal-facing repository-management wording from the public docs while preserving the useful data/checkpoint guidance.

## What Changed

- Reworded README data and artifact notes to focus on Zenodo distribution and repository scope.
- Removed `ignored by git`, `Do not commit`, and `not in git` style phrasing from README-facing text.
- Clarified that the example ensemble config is a four-model setup and weights must match the configured model count.
- Reworked `DATA_POLICY.md` as a public-facing data/artifact scope document.

## Validation

- `git diff --check`
- Searched README and DATA_POLICY for removed internal-facing phrases.